### PR TITLE
Refactorings to decouple mpv client

### DIFF
--- a/.idea/.idea.Shizou.AnimePresence/.idea/vcs.xml
+++ b/.idea/.idea.Shizou.AnimePresence/.idea/vcs.xml
@@ -1,5 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
+  <component name="CommitMessageInspectionProfile">
+    <profile version="1.0">
+      <inspection_tool class="BodyLimit" enabled="true" level="WARNING" enabled_by_default="true" />
+      <inspection_tool class="SubjectBodySeparation" enabled="true" level="WARNING" enabled_by_default="true" />
+      <inspection_tool class="SubjectLimit" enabled="true" level="WARNING" enabled_by_default="true">
+        <option name="RIGHT_MARGIN" value="50" />
+      </inspection_tool>
+    </profile>
+  </component>
   <component name="VcsDirectoryMappings">
     <mapping directory="" vcs="Git" />
   </component>

--- a/DiscordPipeClient.cs
+++ b/DiscordPipeClient.cs
@@ -181,6 +181,27 @@ public class DiscordPipeClient : IDisposable
         _writeLock.Release();
         cancelToken.ThrowIfCancellationRequested();
     }
+
+    private static string SmartStringTrim(string str, int length)
+    {
+        if (str.Length <= length)
+            return str;
+        return str[..str[..(length + 1)].LastIndexOf(' ')] + "...";
+    }
+
+    public static RichPresence CreateNewPresence(QueryInfo queryInfo, bool paused, double playbackTime, double timeLeft) =>
+        new()
+        {
+            details = SmartStringTrim(queryInfo.AnimeName, 64),
+            state = $"{queryInfo.EpisodeType} {queryInfo.EpisodeNumber}{(queryInfo.EpisodeCount is null ? string.Empty : $" of {queryInfo.EpisodeCount}")}",
+            timestamps = paused ? null : TimeStamps.FromPlaybackPosition(playbackTime, timeLeft),
+            assets = new Assets
+            {
+                large_image = string.IsNullOrWhiteSpace(queryInfo.PosterUrl) ? "mpv" : queryInfo.PosterUrl,
+                large_text = string.IsNullOrWhiteSpace(queryInfo.EpisodeName) ? "mpv" : SmartStringTrim(queryInfo.EpisodeName, 64),
+            },
+            buttons = queryInfo.AnimeUrl is null ? [] : [new Button { label = "View Anime", url = queryInfo.AnimeUrl }]
+        };
 }
 
 [SuppressMessage("ReSharper", "InconsistentNaming")]

--- a/DiscordPipeClient.cs
+++ b/DiscordPipeClient.cs
@@ -78,7 +78,7 @@ public class DiscordPipeClient : IDisposable
     {
         if (!_isReady)
             return;
-        
+
         var cmd = new PresenceCommand(ProcessId, presence);
         var frame = new Message(Command.SET_ACTIVITY.ToString(), null, Guid.NewGuid().ToString(), null, cmd);
         await WriteFrameAsync(frame, cancelToken);
@@ -193,7 +193,8 @@ public class DiscordPipeClient : IDisposable
         new()
         {
             details = SmartStringTrim(queryInfo.AnimeName, 64),
-            state = $"{queryInfo.EpisodeType} {queryInfo.EpisodeNumber}{(queryInfo.EpisodeCount is null ? string.Empty : $" of {queryInfo.EpisodeCount}")}",
+            state =
+                $"{queryInfo.EpisodeType} {queryInfo.EpisodeNumber}{(queryInfo.EpisodeType != "Episode" || queryInfo.EpisodeCount is null ? string.Empty : $" of {queryInfo.EpisodeCount}")}",
             timestamps = paused ? null : TimeStamps.FromPlaybackPosition(playbackTime, timeLeft),
             assets = new Assets
             {

--- a/Program.cs
+++ b/Program.cs
@@ -1,16 +1,18 @@
 ﻿using Shizou.AnimePresence;
 
+
 if (args.Length != 2)
     throw new InvalidOperationException("Must provide two arguments: discord client id and ipc socket/pipe name");
 
 var discordClientId = args[0];
 var socketName = args[1];
+var allowRestricted = bool.Parse(args[2]);
 
 try
 {
     var cancelSource = new CancellationTokenSource();
     using var discordClient = new DiscordPipeClient(discordClientId);
-    using var mpvClient = new MpvPipeClient(socketName, discordClient);
+    using var mpvClient = new MpvPipeClient(socketName, discordClient, allowRestricted);
     await mpvClient.Connect(cancelSource.Token);
     var tasks = new[] { mpvClient.ReadLoop(cancelSource.Token), mpvClient.QueryLoop(cancelSource.Token), discordClient.ReadLoop(cancelSource.Token) };
 
@@ -24,4 +26,9 @@ catch (AggregateException ae)
 }
 catch (Exception e) when (e is OperationCanceledException or IOException)
 {
+}
+
+public static partial class Program
+{
+    public const string AppId = "07a58b50-5109-5aa3-abbc-782fed0df04f";
 }

--- a/Program.cs
+++ b/Program.cs
@@ -1,8 +1,8 @@
 ﻿using Shizou.AnimePresence;
 
 
-if (args.Length != 2)
-    throw new InvalidOperationException("Must provide two arguments: discord client id and ipc socket/pipe name");
+if (args.Length != 3)
+    throw new InvalidOperationException("Must provide three arguments: discord client id, ipc socket/pipe name, and allow restricted (bool)");
 
 var discordClientId = args[0];
 var socketName = args[1];

--- a/QueryInfo.cs
+++ b/QueryInfo.cs
@@ -1,0 +1,95 @@
+﻿using System.Web;
+
+namespace Shizou.AnimePresence;
+
+public class QueryInfo
+{
+    private QueryInfo()
+    {
+    }
+
+    public static QueryInfo? GetQueryInfo(string path, bool allowRestricted)
+    {
+        if (!Uri.TryCreate(path, UriKind.Absolute, out var uri) || !new[] { Uri.UriSchemeHttp, Uri.UriSchemeHttps }.Contains(uri.Scheme))
+        {
+            Console.WriteLine("Path is not an HTTP(S) URL");
+            return null;
+        }
+
+        var fileQuery = HttpUtility.ParseQueryString(uri.Query);
+        if (!string.Equals(fileQuery.Get("appId"), Program.AppId, StringComparison.OrdinalIgnoreCase))
+        {
+            Console.WriteLine("The app id is not present or does not match");
+            return null;
+        }
+
+        var restrictedSpecified = bool.TryParse(fileQuery.Get("restricted"), out var restricted);
+
+        if (!allowRestricted)
+        {
+            if (!restrictedSpecified)
+            {
+                Console.Error.WriteLine("Restricted is a required parameter when restricted files are disallowed");
+                return null;
+            }
+
+            if (restricted)
+            {
+                Console.Error.WriteLine("Not allowing restricted file");
+                return null;
+            }
+        }
+
+        if ((fileQuery.Get("epNo") ?? fileQuery.Get("episodeNumber")) is not { } episodeNumber)
+        {
+            Console.Error.WriteLine("Episode number is a required parameter");
+            return null;
+        }
+
+        var animeId = fileQuery.Get("animeId");
+        if (fileQuery.Get("animeName") is not { } animeName)
+        {
+            Console.Error.WriteLine("Anime name is a required parameter");
+            return null;
+        }
+
+        var episodeType = (fileQuery.Get("epType") ?? fileQuery.Get("episodeType")) ?? episodeNumber[0] switch
+        {
+            'S' => "Special",
+            'C' => "Credit",
+            'T' => "Trailer",
+            'P' => "Parody",
+            'O' => "Other",
+            _ => "Episode"
+        };
+
+        // Don't show poster if it could be NSFW
+        var posterUrl = restrictedSpecified && !restricted
+            ? fileQuery.Get("posterUrl") ??
+              (fileQuery.Get("posterFilename") is { } filename
+                  ? $"https://cdn.anidb.net/images/main/{filename}"
+                  : null)
+            : null;
+
+        return new QueryInfo
+        {
+            EpisodeName = fileQuery.Get("episodeName"),
+            AnimeId = animeId,
+            AnimeName = animeName,
+            EpisodeNumber = episodeNumber,
+            EpisodeType = episodeType,
+            EpisodeCount = fileQuery.Get("epCount") ?? fileQuery.Get("episodeCount"),
+            AnimeUrl = fileQuery.Get("animeUrl") ?? (animeId is null ? null : $"https://anidb.net/anime/{animeId}"),
+            PosterUrl = posterUrl
+        };
+    }
+
+    public string? AnimeId { get; init; }
+    public required string AnimeName { get; init; }
+    public required string EpisodeNumber { get; init; }
+    public required string EpisodeType { get; init; }
+    public string? EpisodeName { get; init; }
+    public string? EpisodeCount { get; init; }
+    public string? AnimeUrl { get; init; }
+    public string? PosterUrl { get; init; }
+}

--- a/QueryInfo.cs
+++ b/QueryInfo.cs
@@ -63,6 +63,9 @@ public class QueryInfo
             _ => "Episode"
         };
 
+        if (!char.IsDigit(episodeNumber[0]) && episodeType != "Episode")
+            episodeNumber = episodeNumber[1..];
+
         // Don't show poster if it could be NSFW
         var posterUrl = restrictedSpecified && !restricted
             ? fileQuery.Get("posterUrl") ??

--- a/main.lua
+++ b/main.lua
@@ -1,6 +1,8 @@
 ﻿local mp = require("mp")
 local utils = require("mp.utils")
 
+local allow_restricted = "false"
+
 local discord_client_id_str = "1230418743734042694"
 local pid = utils.getpid()
 local socket_name = "/tmp/mpv-socket" .. '-' .. pid
@@ -36,7 +38,7 @@ local function start()
 	presence_command, err = mp.command_native_async({
 		name = "subprocess",
 		playback_only = false,
-		args = { exePath, discord_client_id_str, socket_name },
+		args = { exePath, discord_client_id_str, socket_name, allow_restricted },
 	})
 	if err ~= nil then
         mp.msg.error("Subprocess failed to start: " .. err)


### PR DESCRIPTION
* Decouple MpvPipeClient from query parsing and presence creation
* Add Restricted query parameter and only display poster if not restricted
  * Also add allowRestricted argument rich presence will not be created for restricted content if this is false 
* Add posterUrl query parameter for custom image source
* Add animeUrl query parameter for custom button url